### PR TITLE
Add ext-zip to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
+        "ext-zip": "*",
         "league/flysystem": "~1.0@alpha"
     },
     "require-dev": {


### PR DESCRIPTION
There is a requirement on the PHP Zip Extension. This should be listed in the composer.json.